### PR TITLE
feat: add rack-cors gem and configure CORS middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,9 @@ group :development, :test do
   gem 'simplecov'
 end
 
+# CORS handling for cross-origin requests
+gem 'rack-cors', '~> 1.0.3'
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
@@ -123,8 +126,6 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-  #
-  gem 'rack-cors', '~> 1.0.3'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,8 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  #
+  gem 'rack-cors', '~> 1.0.3'
 end
 
 group :test do

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,9 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+    resource '*',
+             headers: :any,
+             methods: %i[get post put delete options],
+             expose: 'X-Total-Count'
+  end
+end


### PR DESCRIPTION
This pull request introduces CORS (Cross-Origin Resource Sharing) support to the application by adding the `rack-cors` gem and configuring it to allow requests from any origin. This enables the app to accept cross-origin HTTP requests, which is often necessary for frontend-backend integrations and API development.

CORS support:

* Added the `rack-cors` gem to the development group in the `Gemfile` to enable CORS middleware.
* Created a new initializer `config/initializers/cors.rb` to configure the CORS policy, allowing requests from any origin (`'*'`), permitting any headers, and supporting common HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`). Also exposes the `X-Total-Count` header.