### PR TITLE
feat: add delete session error to openapi

### DIFF
--- a/docs/api/v1/openapi.yaml
+++ b/docs/api/v1/openapi.yaml
@@ -70,6 +70,12 @@ paths:
       responses:
         '204':
           description: Successfully deleted the session.
+        "401":
+          description: Invalid session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/v1/registrations:
     post:
       summary: Creates a new user registration.


### PR DESCRIPTION
This pull request adds an additional error response to the session deletion endpoint in the OpenAPI specification. The new response documents what happens when an invalid session is provided.

* API documentation update:
  * Added a `401` error response with a description and schema reference for invalid sessions to the `DELETE /api/v1/sessions` endpoint in `docs/api/v1/openapi.yaml`.